### PR TITLE
Build docker.Authorizer in Prepare

### DIFF
--- a/plugins/rest/auth.go
+++ b/plugins/rest/auth.go
@@ -146,22 +146,6 @@ func (ap *bearerAuthPlugin) NewClient(c Config) (*http.Client, error) {
 
 // Prepare adds the token to the request header. Implements the rest.HTTPAuthPlugin interface.
 func (ap *bearerAuthPlugin) Prepare(req *http.Request) error {
-	return ap.addAuthorizationHeader(req.Header)
-}
-
-// AuthHeader explicitly returns the header that would be added to the request with Prepare
-// this will be used by the OCIDownloader to sign the request to the OCI service for the
-// authenticated token flow. Implements the download.httpHeaderAuthPlugin interface.
-func (ap *bearerAuthPlugin) AuthHeader() (http.Header, error) {
-	header := make(http.Header)
-	err := ap.addAuthorizationHeader(header)
-	if err != nil {
-		return nil, err
-	}
-	return header, nil
-}
-
-func (ap *bearerAuthPlugin) addAuthorizationHeader(header http.Header) error {
 	token := ap.Token
 
 	if ap.TokenPath != "" {
@@ -176,7 +160,8 @@ func (ap *bearerAuthPlugin) addAuthorizationHeader(header http.Header) error {
 		token = base64.StdEncoding.EncodeToString([]byte(token))
 	}
 
-	header.Add("Authorization", fmt.Sprintf("%v %v", ap.Scheme, token))
+	req.Header.Add("Authorization", fmt.Sprintf("%v %v", ap.Scheme, token))
+
 	return nil
 }
 


### PR DESCRIPTION
### Why the changes in this PR are needed?
I avoids the addition of a new interface that is only implemented by one of the `HTTPAuthPlugin` implementations and leaves the plugins in a more consistent state. It also removes some complexity around handling the additional interface and special case.
This way also avoids any potential danger of side-effects by not calling `Prepare` during setup of the `pluginAuthorizer`.

### What are the changes in this PR?

It uses a modified request header after a pass through `HTTPAuthPlugin.Prepare` to pass it to the docker authorizer with `docker.WithAuthHeader(req.Header)` as suggested in https://github.com/open-policy-agent/opa/pull/6045#issuecomment-1622432569.
It does so in the `pluginAuthorizer.Prepare` func and thereby abides to the normal calling semantics. The downside is that one of the `pluginAuthorizer` fields only gets initialized after setup which can be harder to follow.

### Notes to assist PR review:

Builds on top of https://github.com/open-policy-agent/opa/pull/6045
